### PR TITLE
added support to openssl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 HOME=$(shell pwd)
-VERSION=1.6.0
+VERSION=1.6.4
 RELEASE=1
 
 all: build

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 	mkdir -p ./rpmbuild/SPECS/ ./rpmbuild/SOURCES/
 
 download-upstream:
-	./download haproxy-${VERSION}.tar.gz http://www.haproxy.org/download/1.6/src/haproxy-${VERSION}.tar.gz
+	./download haproxy-${VERSION}.tar.gz http://www.haproxy.org/download/1.7/src/haproxy-${VERSION}.tar.gz
 
 build: clean download-upstream
 	mkdir -p ./SPECS/ ./SOURCES/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 HOME=$(shell pwd)
-VERSION=1.6.4
+VERSION=1.7.2
 RELEASE=1
 
 all: build

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-# A Recipe for a haproxy 1.6.4 stable version RPM on CentOS
+# A Recipe for a haproxy 1.7.2 stable version RPM on CentOS
 
 Perform the following on a build box as a regular user.
 
@@ -16,8 +16,8 @@ Install rpmdevtools from the [EPEL][epel] repository:
 
 ## Download haproxy
 
-    wget http://www.haproxy.org/download/1.6/src/haproxy-1.6.4.tar.gz
-    mv haproxy-1.6.4.tar.gz rpmbuild/SOURCES/
+    wget http://www.haproxy.org/download/1.6/src/haproxy-1.7.2.tar.gz
+    mv haproxy-1.7.2.tar.gz rpmbuild/SOURCES/
 
 ## Get Necessary System-specific Configs
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-# A Recipe for a haproxy 1.5 stable version RPM on CentOS
+# A Recipe for a haproxy 1.6.4 stable version RPM on CentOS
 
 Perform the following on a build box as a regular user.
 
@@ -16,18 +16,18 @@ Install rpmdevtools from the [EPEL][epel] repository:
 
 ## Download haproxy
 
-    wget http://www.haproxy.org/download/1.6/src/haproxy-1.6.0.tar.gz
-    mv haproxy-1.6.0.tar.gz ~/rpmbuild/SOURCES/
+    wget http://www.haproxy.org/download/1.6/src/haproxy-1.6.4.tar.gz
+    mv haproxy-1.6.4.tar.gz rpmbuild/SOURCES/
 
 ## Get Necessary System-specific Configs
 
-    git clone git://github.com/bluerail/haproxy-centos.git
-    cp haproxy-centos/conf/* ~/rpmbuild/SOURCES/
-    cp haproxy-centos/spec/* ~/rpmbuild/SPECS/
+    git clone git@github.com:ITV/rpm-haproxy.git
+    cp haproxy-centos/SOURCES/* rpmbuild/SOURCES/
+    cp haproxy-centos/SPECS/* rpmbuild/SPECS/
 
 ## Build the RPM
 
-    cd ~/rpmbuild/
+    cd rpmbuild/
     rpmbuild -ba SPECS/haproxy.spec
 
 The resulting RPM will be in ~/rpmbuild/RPMS/x86_64
@@ -36,6 +36,9 @@ The resulting RPM will be in ~/rpmbuild/RPMS/x86_64
 
 Based on the Red Hat 6.4 RPM spec for haproxy 1.4.
 
-Maintained by [Martijn Storck](martijn@bluerail.nl)
+Maintained by [Russ Clare](russ.clare@itv.com)
 
 [EPEL]: http://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F
+
+Forked from https://github.com/swisstxt/rpm-haproxy (1.6 Dev support) which was Forked from https://github.com/bluerail/haproxy-centos (1.5 Stable support)
+

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -1,6 +1,6 @@
 Summary: HA-Proxy is a TCP/HTTP reverse proxy for high availability environments
 Name: haproxy
-Version: 1.6.0
+Version: 1.6.4
 Release: 1
 License: GPL
 Group: System Environment/Daemons

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -36,7 +36,7 @@ risking the system's stability.
 %define __perl_requires /bin/true
 
 %build
-%{__make} USE_PCRE=1 DEBUG="" ARCH=%{_target_cpu} TARGET=linux2628
+%{__make} USE_PCRE=1 USE_LINUX_TPROXY=1 USE_ZLIB=1 USE_REGPARM=1 USE_OPENSSL=1 DEBUG="" ARCH=%{_target_cpu} TARGET=linux2628 
 
 %install
 [ "%{buildroot}" != "/" ] && %{__rm} -rf %{buildroot}
@@ -89,6 +89,7 @@ fi
 - updated to 1.7.2
 - changed to target linux2628 due to cpu-map and USE_CPU_AFFINITY
 - included user/group haproxy in package
+- added support to openssl
 
 * Tue Oct 13 2015 Willy Tarreau <w@1wt.eu>
 - updated to 1.6.0

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -1,14 +1,17 @@
+# https://github.com/ITV/rpm-haproxy
 Summary: HA-Proxy is a TCP/HTTP reverse proxy for high availability environments
 Name: haproxy
-Version: 1.6.4
+Version: 1.7.2
 Release: 1
 License: GPL
 Group: System Environment/Daemons
 URL: http://haproxy.1wt.eu/
-Source0: http://haproxy.1wt.eu/download/1.5/src/devel/%{name}-%{version}.tar.gz
+Source0: http://haproxy.1wt.eu/download/1.7/src/devel/%{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-root
 BuildRequires: pcre-devel
 Requires: /sbin/chkconfig, /sbin/service
+Requires(pre): /usr/sbin/useradd, /usr/bin/getent
+Requires(postun): /usr/sbin/userdel
 
 %description
 HA-Proxy is a TCP/HTTP reverse proxy which is particularly suited for high
@@ -33,7 +36,7 @@ risking the system's stability.
 %define __perl_requires /bin/true
 
 %build
-%{__make} USE_PCRE=1 DEBUG="" ARCH=%{_target_cpu} TARGET=linux26
+%{__make} USE_PCRE=1 DEBUG="" ARCH=%{_target_cpu} TARGET=linux2628
 
 %install
 [ "%{buildroot}" != "/" ] && %{__rm} -rf %{buildroot}
@@ -50,7 +53,11 @@ risking the system's stability.
  
 %clean
 [ "%{buildroot}" != "/" ] && %{__rm} -rf %{buildroot}
- 
+
+%pre
+/usr/bin/getent group haproxy || /usr/sbin/groupadd -r haproxy
+/usr/bin/getent passwd haproxy || /usr/sbin/useradd -r -d /var/lib/haproxy -s /sbin/nologin haproxy -g haproxy
+
 %post
 /sbin/chkconfig --add %{name}
 
@@ -64,6 +71,8 @@ fi
 if [ "$1" -ge "1" ]; then
   /sbin/service %{name} condrestart >/dev/null 2>&1 || :
 fi
+/usr/sbin/groupdel haproxy
+/usr/sbin/userdel haproxy
 
 %files
 %defattr(-,root,root)
@@ -76,6 +85,11 @@ fi
 %attr(0755,root,root) %config %{_sysconfdir}/rc.d/init.d/%{name}
 
 %changelog
+* Tue Feb  6 2017 Tiago Cruz <tiago.cruz@movile.com>
+- updated to 1.7.2
+- changed to target linux2628 due to cpu-map and USE_CPU_AFFINITY
+- included user/group haproxy in package
+
 * Tue Oct 13 2015 Willy Tarreau <w@1wt.eu>
 - updated to 1.6.0
 

--- a/SPECS/haproxy.spec
+++ b/SPECS/haproxy.spec
@@ -8,7 +8,8 @@ Group: System Environment/Daemons
 URL: http://haproxy.1wt.eu/
 Source0: http://haproxy.1wt.eu/download/1.7/src/devel/%{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-root
-BuildRequires: pcre-devel
+# to build using ubuntu
+#BuildRequires: pcre-devel
 Requires: /sbin/chkconfig, /sbin/service
 Requires(pre): /usr/sbin/useradd, /usr/bin/getent
 Requires(postun): /usr/sbin/userdel


### PR DESCRIPTION
```
%changelog
* Tue Feb  6 2017 Tiago Cruz <tiago.cruz@movile.com>
- updated to 1.7.2
- changed to target linux2628 due to cpu-map and USE_CPU_AFFINITY
- included user/group haproxy in package
- added support to openssl
```